### PR TITLE
Changed windows command for montage to new magick format

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -389,7 +389,7 @@ func decker(filename string) {
 		//We use imagemagick's montage to generate the image,
 		//somebody could code it in go using it's image library but I can't be bothered as imagemagick already does a perfect job.
 		//Why rewrite something that already exists when you can just glue a bunch of different programs together?
-		command := "montage"
+		command := "magick"
 
 		//Windows doesn't like it when you drag a deck file onto decker from a different folder.
 		//Then it makes the different folder the current working directory and complains
@@ -398,15 +398,15 @@ func decker(filename string) {
 			command, err = filepath.Abs(os.Args[0])
 			command = filepath.Dir(command)
 			if err != nil {
-				command = "montage"
+				command = "magick"
 			} else {
-				command += "/montage"
+				command = "magick"
 			}
 		}
 
 		//Run montage. TODO maybe make these values tweakable, for now they do a fine job.
-		montage := exec.Command(command, "-background", "rgb(23,20,15)", "-tile", "10x7", "-quality", "100", "-geometry", "410x586!+0+0", temp+"/*.jpg", output)
-		text, err := montage.CombinedOutput()
+		magick := exec.Command(command, "montage", "-background", "rgb(23,20,15)", "-tile", "10x7", "-quality", "100", "-geometry", "410x586!+0+0", temp+"/*.jpg", output)
+		text, err := magick.CombinedOutput()
 		if err != nil {
 			fmt.Print(string(text))
 			handle(err)


### PR DESCRIPTION
Montage is now a subcommand of magick, and installs that way by default, instead of montage.exe, so it will confuse new users. This way will work out of the box if the newest version of imagemagick is installed. See here: https://www.imagemagick.org/script/montage.php